### PR TITLE
Add support for empty base images

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/examples/macros.py
+++ b/examples/macros.py
@@ -1,0 +1,4 @@
+def pants_at_least(version: str) -> bool:
+    pants = __import__("pants")
+
+    return pants.version.PANTS_SEMVER >= pants.version.Version(version)

--- a/examples/oci/BUILD
+++ b/examples/oci/BUILD
@@ -31,7 +31,7 @@ oci_image_build(
 
 oci_image_build(
     name="with_empty_base",
-    base=[f'//:empty'],
+    base=[f"//:empty"],
     packages=[
         ":example2",
     ],

--- a/examples/oci/BUILD
+++ b/examples/oci/BUILD
@@ -30,7 +30,7 @@ oci_image_build(
 )
 
 # in pants 2.15+ we use a synthetic target so no need to declare an empty image base
-empty_base = "//:empty"
+empty_base = "//:empty"  # also see [oci].empty_image_target configuration
 
 if not pants_at_least("2.15.0.dev0"):
     empty_base = ":empty"

--- a/examples/oci/BUILD
+++ b/examples/oci/BUILD
@@ -29,9 +29,18 @@ oci_image_build(
     tag="latest",
 )
 
+# in pants 2.15+ we use a synthetic target so no need to declare an empty image base
+empty_base = "//:empty"
+
+if not pants_at_least("2.15.0.dev0"):
+    empty_base = ":empty"
+    oci_image_empty(
+        name="empty",
+    )
+
 oci_image_build(
     name="with_empty_base",
-    base=[f"//:empty"],
+    base=[empty_base],
     packages=[
         ":example2",
     ],

--- a/examples/oci/BUILD
+++ b/examples/oci/BUILD
@@ -28,3 +28,12 @@ oci_image_build(
     repository="harbor.sbg.dev/test/pants-plugin-oci-example-2",
     tag="latest",
 )
+
+oci_image_build(
+    name="with_empty_base",
+    base=[f'//:empty'],
+    packages=[
+        ":example2",
+    ],
+    tag="latest",
+)

--- a/pants-plugins/214.lock
+++ b/pants-plugins/214.lock
@@ -10,7 +10,8 @@
 //   ],
 //   "generated_with_requirements": [
 //     "pantsbuild.pants.testutil<2.15.0,>=2.14.0a0",
-//     "pantsbuild.pants<2.15.0,>=2.14.0a0"
+//     "pantsbuild.pants<2.15.0,>=2.14.0a0",
+//     "pytest"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -504,13 +505,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
-              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
+              "hash": "ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09",
+              "url": "https://files.pythonhosted.org/packages/f8/7d/e3adad613703c86d62aa991b45d6f090cf59975078a8c8100b50a0c86948/importlib_metadata-6.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
-              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
+              "hash": "43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20",
+              "url": "https://files.pythonhosted.org/packages/e2/d8/3d431bade4598ad9e33be9da41d15e6607b878008e922d122659ab01b077/importlib_metadata-6.1.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -539,7 +540,7 @@
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "6"
+          "version": "6.1"
         },
         {
           "artifacts": [
@@ -1511,7 +1512,8 @@
   "prefer_older_binary": false,
   "requirements": [
     "pantsbuild.pants.testutil<2.15.0,>=2.14.0a0",
-    "pantsbuild.pants<2.15.0,>=2.14.0a0"
+    "pantsbuild.pants<2.15.0,>=2.14.0a0",
+    "pytest"
   ],
   "requires_python": [
     "<3.10,>=3.7"

--- a/pants-plugins/215.lock
+++ b/pants-plugins/215.lock
@@ -10,7 +10,8 @@
 //   ],
 //   "generated_with_requirements": [
 //     "pantsbuild.pants.testutil<2.16.0,>=2.15.0a0",
-//     "pantsbuild.pants<2.16.0,>=2.15.0a0"
+//     "pantsbuild.pants<2.16.0,>=2.15.0a0",
+//     "pytest"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -522,13 +523,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
-              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
+              "hash": "ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09",
+              "url": "https://files.pythonhosted.org/packages/f8/7d/e3adad613703c86d62aa991b45d6f090cf59975078a8c8100b50a0c86948/importlib_metadata-6.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
-              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
+              "hash": "43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20",
+              "url": "https://files.pythonhosted.org/packages/e2/d8/3d431bade4598ad9e33be9da41d15e6607b878008e922d122659ab01b077/importlib_metadata-6.1.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -557,7 +558,7 @@
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "6"
+          "version": "6.1"
         },
         {
           "artifacts": [
@@ -1530,7 +1531,8 @@
   "prefer_older_binary": false,
   "requirements": [
     "pantsbuild.pants.testutil<2.16.0,>=2.15.0a0",
-    "pantsbuild.pants<2.16.0,>=2.15.0a0"
+    "pantsbuild.pants<2.16.0,>=2.15.0a0",
+    "pytest"
   ],
   "requires_python": [
     "<3.10,>=3.7"

--- a/pants-plugins/216.lock
+++ b/pants-plugins/216.lock
@@ -10,7 +10,8 @@
 //   ],
 //   "generated_with_requirements": [
 //     "pantsbuild.pants.testutil==2.16.0a0",
-//     "pantsbuild.pants==2.16.0a0"
+//     "pantsbuild.pants==2.16.0a0",
+//     "pytest"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -522,13 +523,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
-              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
+              "hash": "ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09",
+              "url": "https://files.pythonhosted.org/packages/f8/7d/e3adad613703c86d62aa991b45d6f090cf59975078a8c8100b50a0c86948/importlib_metadata-6.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
-              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
+              "hash": "43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20",
+              "url": "https://files.pythonhosted.org/packages/e2/d8/3d431bade4598ad9e33be9da41d15e6607b878008e922d122659ab01b077/importlib_metadata-6.1.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -557,7 +558,7 @@
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "6"
+          "version": "6.1"
         },
         {
           "artifacts": [
@@ -1690,7 +1691,8 @@
   "prefer_older_binary": false,
   "requirements": [
     "pantsbuild.pants.testutil==2.16.0a0",
-    "pantsbuild.pants==2.16.0a0"
+    "pantsbuild.pants==2.16.0a0",
+    "pytest"
   ],
   "requires_python": [
     "<3.10,>=3.7"

--- a/pants-plugins/BUILD
+++ b/pants-plugins/BUILD
@@ -18,11 +18,12 @@ for name, constraint in name_to_constraint.items():
     )
 
 all_targets = ("pants-plugins", *tuple(name_to_constraint.keys()))
+
 __defaults__(
     {
         python_sources: dict(resolve=parametrize(*all_targets)),
         python_tests: dict(
-            resolve=parametrize(*all_targets[1:])
-        ),  # we don't parametrize test for host... assume test with ::
+            resolve=parametrize(*all_targets[1:]),
+        ),
     }
 )

--- a/pants-plugins/BUILD
+++ b/pants-plugins/BUILD
@@ -12,8 +12,9 @@ for name, constraint in name_to_constraint.items():
         requirements=(
             f"pantsbuild.pants.testutil{constraint}",
             f"pantsbuild.pants{constraint}",
+            "pytest",
         ),
-        modules=("pants.testutil", "pants"),
+        modules=("pants.testutil", "pants", "pytest"),
         resolve=name,
     )
 

--- a/pants-plugins/oci/BUILD
+++ b/pants-plugins/oci/BUILD
@@ -18,3 +18,15 @@ python_distribution_with_secret(
     repositories=["@pypi"],
     repo_secrets={"@pypi": "//examples/bitwarden:pypi_token"},
 )
+
+__defaults__(
+    {
+        python_tests: dict(
+            dependencies=[
+                "//BUILD_ROOT:files",
+                "//pants-plugins/oci/pants_backend_oci/register.py",
+            ],
+        ),
+    },
+    extend=True,
+)

--- a/pants-plugins/oci/CHANGELOG.md
+++ b/pants-plugins/oci/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- **Adds support for empty base images** (`FROM scratch`)
+
+  This change enables you to use `base=["//:empty"]` to start from a completely empty
+  container. This can be useful to produce containers with statically linked binaries that require
+  no runtime environment at all.
+
+  Note that for Pants 2.14 you'll need to manually declare the base image: `oci_image_empty(name="empty")`.
+
+  - To change the target name, set `[oci].empty_image_target` in `pants.toml`.
+
 ## 0.3.1 - 2023-03-16
 
 - Handle files when building layers

--- a/pants-plugins/oci/README.md
+++ b/pants-plugins/oci/README.md
@@ -16,7 +16,6 @@ This is a backend implementing support for building OCI images in pants; running
 * Currently there's no support for pulling tags, as that would break determinism
 * Multi-platform SHA/.sig is untested/unsupported
 * skopeo doesn't support MacOS, preventing pulling and pushing images.
-* No empty image base
 * No "in-container" build steps
 
 ## Targets
@@ -25,9 +24,10 @@ There's three targets currently implemented:
 
 * `oci_pull_image`
 * `oci_pull_images`
-* `oci_build_image`
+* `oci_image_build`
+* `oci_image_empty`
 
-There are also plans to support targets optimized for various languages.
+There are also plans to support targets optimized for various languages. There's currently one special target for Python, which will preferentially set the entrypoint to Pex files, `oci_python_image`.
 
 ### `oci_pull_image`
 
@@ -121,5 +121,21 @@ oci_python_image(
 | `python_main` | The main file to run                                                           | The last `.pex` in the dependency list                |
 | `repository`  | Fully qualified repository name                                                | Required when publishing                              |
 | `tag`         | Remote tag to use                                                              | Required when publishing                              |
+| `decsription` | A description of the target                                                    |                                                       |
+| `tags`        | List of tags                                                                   | `[]`                                                  |
+
+### `oci_image_empty`
+
+An empty base image with no contents at all. It is suggested to declare this in the root and use `//:empty` to reference it. **Note that from 2.15 this is automatically created by the plugin using a synthetic target.**
+
+``` python
+oci_image_empty(
+    name="empty",
+)
+```
+
+| Argument      | Meaning                                                                        | Default value                                         |
+|---------------|--------------------------------------------------------------------------------|-------------------------------------------------------|
+| `name`        | The target name                                                                | Same as any other target, which is the directory name |
 | `decsription` | A description of the target                                                    |                                                       |
 | `tags`        | List of tags                                                                   | `[]`                                                  |

--- a/pants-plugins/oci/pants_backend_oci/BUILD
+++ b/pants-plugins/oci/pants_backend_oci/BUILD
@@ -1,1 +1,5 @@
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/pants-plugins/oci/pants_backend_oci/goals/BUILD
+++ b/pants-plugins/oci/pants_backend_oci/goals/BUILD
@@ -1,6 +1,3 @@
 python_sources()
 
-python_tests(
-    name="tests",
-    dependencies=["//BUILD_ROOT:files", "//pants-plugins/oci/pants_backend_oci/register.py"],
-)
+python_tests(name="tests")

--- a/pants-plugins/oci/pants_backend_oci/register.py
+++ b/pants-plugins/oci/pants_backend_oci/register.py
@@ -1,4 +1,3 @@
-from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.rules import collect_rules
 
 from pants_backend_oci import (
@@ -32,15 +31,3 @@ def rules():
         *util_rules.rules(),
         *synthetic_targets.rules(),
     ]
-
-
-def make_empty():
-    return "empty"
-
-
-def build_file_aliases():
-    return BuildFileAliases(
-        objects={
-            "empty": make_empty,
-        },
-    )

--- a/pants-plugins/oci/pants_backend_oci/register.py
+++ b/pants-plugins/oci/pants_backend_oci/register.py
@@ -1,6 +1,14 @@
+from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.rules import collect_rules
 
-from pants_backend_oci import goals, language_target, subsystem, targets, util_rules
+from pants_backend_oci import (
+    goals,
+    language_target,
+    subsystem,
+    synthetic_targets,
+    targets,
+    util_rules,
+)
 from pants_backend_oci.rules import kustomize_inject
 from pants_backend_oci.tools import process
 
@@ -22,4 +30,17 @@ def rules():
         *subsystem.rules(),
         *targets.rules(),
         *util_rules.rules(),
+        *synthetic_targets.rules(),
     ]
+
+
+def make_empty():
+    return "empty"
+
+
+def build_file_aliases():
+    return BuildFileAliases(
+        objects={
+            "empty": make_empty,
+        },
+    )

--- a/pants-plugins/oci/pants_backend_oci/subsystem.py
+++ b/pants-plugins/oci/pants_backend_oci/subsystem.py
@@ -3,11 +3,20 @@ from __future__ import annotations
 from pants.core.util_rules.external_tool import ExternalTool
 from pants.engine.platform import Platform
 from pants.engine.rules import SubsystemRule
+from pants.option.option_types import StrOption
+from pants.version import PANTS_SEMVER, Version
 
 
 class UmociTool(ExternalTool):
-    options_scope = "umoci"
+    options_scope = "oci"
     help = "Wrapper for kustomize."
+
+    if PANTS_SEMVER >= Version("2.15.0.dev0"):
+        empty_image_target = StrOption(
+            default="empty",
+            advanced=False,
+            help="The name of the synthetic target for an empty base image.",
+        )
 
     default_version = "v0.4.7"
     default_known_versions = [

--- a/pants-plugins/oci/pants_backend_oci/synthetic_targets.py
+++ b/pants-plugins/oci/pants_backend_oci/synthetic_targets.py
@@ -8,6 +8,8 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.version import PANTS_SEMVER, Version
 
+from pants_backend_oci.subsystem import UmociTool
+
 RULES = ()
 
 if PANTS_SEMVER >= Version("2.15.0.dev0"):
@@ -22,17 +24,17 @@ if PANTS_SEMVER >= Version("2.15.0.dev0"):
 
     @rule
     async def example_synthetic_targets(
-        request: SyntheticEmptyImageRequest,
+        request: SyntheticEmptyImageRequest, oci: UmociTool
     ) -> SyntheticAddressMaps:
         return SyntheticAddressMaps.for_targets_request(
             request,
             [
                 (
-                    "BUILD.synthetic-example",
+                    "BUILD.oci_image_empty",
                     (
                         TargetAdaptor(
                             "oci_image_empty",
-                            "empty",
+                            oci.empty_image_target,
                         ),
                     ),
                 ),

--- a/pants-plugins/oci/pants_backend_oci/synthetic_targets.py
+++ b/pants-plugins/oci/pants_backend_oci/synthetic_targets.py
@@ -1,0 +1,49 @@
+"""
+
+"""
+from dataclasses import dataclass
+
+from pants.engine.internals.target_adaptor import TargetAdaptor
+from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionRule
+from pants.version import PANTS_SEMVER, Version
+
+RULES = ()
+
+if PANTS_SEMVER >= Version("2.15.0.dev0"):
+    from pants.engine.internals.synthetic_targets import (
+        SyntheticAddressMaps,
+        SyntheticTargetsRequest,
+    )
+
+    @dataclass(frozen=True)
+    class SyntheticEmptyImageRequest(SyntheticTargetsRequest):
+        path: str = SyntheticTargetsRequest.SINGLE_REQUEST_FOR_ALL_TARGETS
+
+    @rule
+    async def example_synthetic_targets(
+        request: SyntheticEmptyImageRequest,
+    ) -> SyntheticAddressMaps:
+        return SyntheticAddressMaps.for_targets_request(
+            request,
+            [
+                (
+                    "BUILD.synthetic-example",
+                    (
+                        TargetAdaptor(
+                            "oci_image_empty",
+                            "empty",
+                        ),
+                    ),
+                ),
+            ],
+        )
+
+    RULES = (
+        *collect_rules(),
+        UnionRule(SyntheticTargetsRequest, SyntheticEmptyImageRequest),
+    )
+
+
+def rules():
+    return RULES

--- a/pants-plugins/oci/pants_backend_oci/synthetic_targets_test.py
+++ b/pants-plugins/oci/pants_backend_oci/synthetic_targets_test.py
@@ -1,0 +1,46 @@
+import pytest
+from pants.build_graph.address import ResolveError
+from pants.core.util_rules import external_tool
+from pants.engine.addresses import Address
+from pants.testutil.rule_runner import RuleRunner, engine_error
+from pants.version import PANTS_SEMVER, Version
+
+from pants_backend_oci.targets import ImageEmpty
+
+pytestmark = pytest.mark.skipif(PANTS_SEMVER < Version("2.15.0.dev0"), reason="no synthetic targets in 2.14")
+
+
+def test_synthetic_target_exists() -> None:
+    from pants_backend_oci import synthetic_targets
+
+    rule_runner = RuleRunner(
+        target_types=[ImageEmpty],
+        rules=[
+            *external_tool.rules(),
+            *synthetic_targets.rules(),
+        ],
+    )
+
+    rule_runner.write_files({})
+    target = rule_runner.get_target(Address("", target_name="empty"))
+
+    assert target is not None
+
+
+def test_synthetic_target_has_custom_name() -> None:
+    from pants_backend_oci import synthetic_targets
+
+    rule_runner = RuleRunner(
+        target_types=[ImageEmpty],
+        rules=[
+            *external_tool.rules(),
+            *synthetic_targets.rules(),
+        ],
+    )
+
+    rule_runner.set_options(["--oci-empty-image-target=custom_name"])
+
+    with engine_error(ResolveError):
+        _ = rule_runner.get_target(Address("", target_name="empty"))
+
+    _ = rule_runner.get_target(Address("", target_name="custom_name"))

--- a/pants-plugins/oci/pants_backend_oci/target_types.py
+++ b/pants-plugins/oci/pants_backend_oci/target_types.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
-from pants.engine.target import BoolField, Dependencies, SpecialCasedDependencies, StringField
+from typing import Optional
+
+from pants.engine.addresses import Address
+from pants.engine.target import (
+    BoolField,
+    Dependencies,
+    ScalarField,
+    SpecialCasedDependencies,
+    StringField,
+)
 from pants.util.strutil import softwrap
 
 
@@ -81,3 +90,17 @@ class ImageRunTty(BoolField):
 
         This prevents the image from running in many situations and isn't recommended."""
     )
+
+
+NoneType = type(None)
+
+
+class ImageEmptyMarker(ScalarField):
+    alias = "_marker"
+    expected_type = type(None)
+    expected_type_description = ""
+    default = None
+
+    @classmethod
+    def compute_value(cls, raw_value: Optional[NoneType], address: Address) -> Optional[NoneType]:
+        return super().compute_value(raw_value, address=address)

--- a/pants-plugins/oci/pants_backend_oci/targets.py
+++ b/pants-plugins/oci/pants_backend_oci/targets.py
@@ -84,9 +84,7 @@ async def generate_from_oci_base_images(
             union_membership,
         )
 
-    result = [
-        create_tgt(name, digest) for (name, digest) in generator[_ImageVariants].value.items()
-    ]
+    result = [create_tgt(name, digest) for (name, digest) in generator[_ImageVariants].value.items()]
 
     return GeneratedTargets(generator, result)
 

--- a/pants-plugins/oci/pants_backend_oci/targets.py
+++ b/pants-plugins/oci/pants_backend_oci/targets.py
@@ -14,6 +14,7 @@ from pants_backend_oci.target_types import (
     ImageBase,
     ImageDependencies,
     ImageDigest,
+    ImageEmptyMarker,
     ImageRepository,
     ImageRepositoryAnonymous,
     ImageRunTty,
@@ -83,7 +84,9 @@ async def generate_from_oci_base_images(
             union_membership,
         )
 
-    result = [create_tgt(name, digest) for (name, digest) in generator[_ImageVariants].value.items()]
+    result = [
+        create_tgt(name, digest) for (name, digest) in generator[_ImageVariants].value.items()
+    ]
 
     return GeneratedTargets(generator, result)
 
@@ -101,8 +104,17 @@ class ImageBuild(Target):
     help = "An imported OCI image."
 
 
+class ImageEmpty(Target):
+    alias = "oci_image_empty"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        ImageEmptyMarker,
+    )
+    help = "An imported OCI image."
+
+
 def targets():
-    return [PullImage, PullImagesGenerator, ImageBuild]
+    return [PullImage, PullImagesGenerator, ImageBuild, ImageEmpty]
 
 
 def rules():

--- a/pants-plugins/oci/pants_backend_oci/util_rules/BUILD
+++ b/pants-plugins/oci/pants_backend_oci/util_rules/BUILD
@@ -1,1 +1,5 @@
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/pants-plugins/oci/pants_backend_oci/util_rules/__init__.py
+++ b/pants-plugins/oci/pants_backend_oci/util_rules/__init__.py
@@ -1,6 +1,7 @@
 from pants_backend_oci.util_rules import (
     archive,
     build_image_bundle,
+    empty_image_bundle,
     image_bundle,
     layer,
     oci_sha,
@@ -18,4 +19,5 @@ def rules():
         *oci_sha.rules(),
         *pull_image_bundle.rules(),
         *unpack.rules(),
+        *empty_image_bundle.rules(),
     ]

--- a/pants-plugins/oci/pants_backend_oci/util_rules/empty_image_bundle.py
+++ b/pants-plugins/oci/pants_backend_oci/util_rules/empty_image_bundle.py
@@ -1,0 +1,81 @@
+"""
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.engine.platform import Platform
+from pants.engine.process import Process, ProcessResult
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.target import FieldSet, Target
+from pants.engine.unions import UnionRule
+
+from pants_backend_oci.subsystem import UmociTool
+from pants_backend_oci.target_types import ImageEmptyMarker
+from pants_backend_oci.tools.process import FusedProcess
+from pants_backend_oci.util_rules.image_bundle import (
+    FallibleImageBundle,
+    FallibleImageBundleRequest,
+    ImageBundle,
+)
+from pants_backend_oci.util_rules.oci_sha import OciSha, OciShaRequest
+
+
+@dataclass(frozen=True)
+class ImageBundleEmptyFieldSet(FieldSet):
+    required_fields = (ImageEmptyMarker,)
+
+
+class ImageBundleEmptyRequest(FallibleImageBundleRequest):
+    target: Target
+
+    field_set_type: ClassVar[type[FieldSet]] = ImageBundleEmptyFieldSet
+
+
+@rule
+async def make_empty_oci_image(
+    request: ImageBundleEmptyRequest,
+    platform: Platform,
+    umoci: UmociTool,
+) -> FallibleImageBundle:
+    umoci = await Get(
+        DownloadedExternalTool,
+        ExternalToolRequest,
+        umoci.get_request(platform),
+    )
+
+    result = await Get(
+        ProcessResult,
+        FusedProcess(
+            (
+                Process(
+                    argv=(umoci.exe, "init", "--layout", "build"),
+                    input_digest=umoci.digest,
+                    description="Creating base OCI layout",
+                ),
+                Process(
+                    argv=(umoci.exe, "new", "--image", "build:build"),
+                    input_digest=umoci.digest,
+                    description="Creating a new empty base image",
+                    output_directories=("build",),
+                ),
+            ),
+        ),
+    )
+
+    image_digest = await Get(OciSha, OciShaRequest(result.output_digest))
+
+    return FallibleImageBundle(
+        ImageBundle(result.output_digest, image_sha=image_digest.image_digest, is_local=True)
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(FallibleImageBundleRequest, ImageBundleEmptyRequest),
+    ]

--- a/pants-plugins/oci/pants_backend_oci/util_rules/empty_image_integration_test.py
+++ b/pants-plugins/oci/pants_backend_oci/util_rules/empty_image_integration_test.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import os
+import tarfile
+from textwrap import dedent
+
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
+from pants.version import PANTS_SEMVER, Version
+
+
+def test_package_empty_with_file() -> None:
+    build_inputs = {
+        "BUILD_ROOT": "",
+        "oci/file.txt": "hello 🎆",
+        "oci/BUILD": dedent(
+            """\
+                file(name="files", source="file.txt")
+
+                oci_image_build(
+                    name="oci",
+                    base=["//:empty"],
+                    packages=[
+                        ":files",
+                    ],
+                )
+                """
+        ),
+    }
+
+    if PANTS_SEMVER < Version("2.15.0.dev0"):
+        build_inputs["oci/BUILD"] = build_inputs["oci/BUILD"].replace("//:empty", ":empty") + dedent(
+            """\
+            oci_image_empty(name="empty")
+            """
+        )
+
+    with setup_tmpdir(build_inputs) as tmpdir:
+        result = run_pants(
+            [
+                "--backend-packages=pants_backend_oci",
+                "--backend-packages=pants.backend.python",
+                "package",
+                f"{tmpdir}/oci:oci",
+            ]
+        )
+
+        result.assert_success()
+
+        output_path = os.path.dirname(os.path.abspath(tmpdir)) + f"/dist/{tmpdir}_oci_oci.None"
+
+        tar = tarfile.open(output_path)
+        json_data = json.load(tar.extractfile("index.json"))
+
+        # only one tag should exist - always, but let's just double-check.
+        assert len(json_data["manifests"]) == 1
+
+        # The head digest of the single tag
+        digest = json_data["manifests"][0]["digest"][7:]
+
+        # The contents of the head digest describes all layers in the tag
+        json_data = json.load(tar.extractfile(f"blobs/sha256/{digest}"))
+
+        # The digest of the last layer (most recently added)
+        layer_digest = json_data["layers"][-1]["digest"][7:]
+
+        # We assume that all layers are tar+gzip, so we need to read tar-from-tar
+        layer_data = tarfile.open(fileobj=tar.extractfile(f"blobs/sha256/{layer_digest}"))
+
+        # We added a single file above, so should only see that here
+        assert layer_data.getnames() == [f"{tmpdir}/oci/file.txt"]
+
+        # For sanity let's double-check that the contents are the same.
+        file_contents = layer_data.extractfile(f"{tmpdir}/oci/file.txt").read().decode("utf-8")
+        assert file_contents == "hello 🎆"

--- a/pants-plugins/oci/pants_backend_oci/util_rules/empty_image_test.py
+++ b/pants-plugins/oci/pants_backend_oci/util_rules/empty_image_test.py
@@ -1,0 +1,41 @@
+from pants.core.util_rules import external_tool
+from pants.engine import process
+from pants.engine.addresses import Address
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.version import PANTS_SEMVER, Version
+
+from pants_backend_oci import synthetic_targets
+from pants_backend_oci.targets import ImageEmpty
+from pants_backend_oci.tools import process as fprocess
+from pants_backend_oci.util_rules import empty_image_bundle, image_bundle, oci_sha
+
+
+def test_empty_image_has_fixed_sha() -> None:
+    GOLDEN = "sha256:e0039d9a394788147eb854e5efe5429723352c288faa47de3bb1abbd53a7f7bb"
+    rule_runner = RuleRunner(
+        target_types=[ImageEmpty],
+        rules=[
+            *empty_image_bundle.rules(),
+            *external_tool.rules(),
+            *oci_sha.rules(),
+            *process.rules(),
+            *fprocess.rules(),
+            *synthetic_targets.rules(),
+            QueryRule(image_bundle.FallibleImageBundle, [empty_image_bundle.ImageBundleEmptyRequest]),
+        ],
+    )
+
+    files = {"BUILD": ""}
+    if PANTS_SEMVER < Version("2.15.0.dev0"):
+        files["BUILD"] = 'oci_image_empty(name="empty")'
+
+    rule_runner.write_files(files)
+    target = rule_runner.get_target(Address("", target_name="empty"))
+
+    request = empty_image_bundle.ImageBundleEmptyRequest(target)
+    result: image_bundle.FallibleImageBundle = rule_runner.request(
+        image_bundle.FallibleImageBundle, [request]
+    )
+
+    assert result.exit_code == 0
+    assert result.output.image_sha == GOLDEN

--- a/pants-plugins/oci/pants_backend_oci/util_rules/pull_image_bundle.py
+++ b/pants-plugins/oci/pants_backend_oci/util_rules/pull_image_bundle.py
@@ -62,9 +62,7 @@ async def pull_oci_image(
         ]
     )
 
-    desc = (
-        f"Download OCI image {request.target.repository.value}@sha256:{request.target.digest.value}"
-    )
+    desc = f"Download OCI image {request.target.repository.value}@sha256:{request.target.digest.value}"
 
     result = await Get(
         ProcessResult,

--- a/pants-plugins/oci/pants_backend_oci/util_rules/pull_image_bundle.py
+++ b/pants-plugins/oci/pants_backend_oci/util_rules/pull_image_bundle.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pants.core.goals.package import PackageFieldSet
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
-from pants.util.logging import LogLevel
 
 from pants_backend_oci.subsystem import SkopeoTool
 from pants_backend_oci.target_types import ImageDigest, ImageRepository, ImageRepositoryAnonymous
@@ -36,15 +34,7 @@ class ImageBundlePullRequest(FallibleImageBundleRequest):
     field_set_type: ClassVar[type[FieldSet]] = ImageBundlePullFieldSet
 
 
-@dataclass(frozen=True)
-class PullImageFieldset(PackageFieldSet):
-    required_fields = (ImageRepository, ImageDigest)
-
-    repository: ImageRepository
-    digest: ImageDigest
-
-
-@rule(level=LogLevel.DEBUG)
+@rule
 async def pull_oci_image(
     request: ImageBundlePullRequest, skopeo_tool: SkopeoTool, platform: Platform
 ) -> FallibleImageBundle:
@@ -72,7 +62,9 @@ async def pull_oci_image(
         ]
     )
 
-    desc = f"Download OCI image {request.target.repository.value}@sha256:{request.target.digest.value}"
+    desc = (
+        f"Download OCI image {request.target.repository.value}@sha256:{request.target.digest.value}"
+    )
 
     result = await Get(
         ProcessResult,

--- a/pants-plugins/pants.lock
+++ b/pants-plugins/pants.lock
@@ -504,13 +504,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
-              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
+              "hash": "ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09",
+              "url": "https://files.pythonhosted.org/packages/f8/7d/e3adad613703c86d62aa991b45d6f090cf59975078a8c8100b50a0c86948/importlib_metadata-6.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
-              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
+              "hash": "43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20",
+              "url": "https://files.pythonhosted.org/packages/e2/d8/3d431bade4598ad9e33be9da41d15e6607b878008e922d122659ab01b077/importlib_metadata-6.1.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -539,7 +539,7 @@
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "6"
+          "version": "6.1"
         },
         {
           "artifacts": [

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,6 @@
 [GLOBAL]
 pants_version = "2.14.0"
+build_file_prelude_globs = ["examples/macros.py"]
 
 pythonpath = [
    "%(buildroot)s/pants-plugins/kustomize",


### PR DESCRIPTION
This adds a new `oci_image_empty` target which enables the creation of completely empty base images. 